### PR TITLE
Really fix PR template newlines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,18 +23,7 @@ Double check this list of stuff that's easy to miss:
 
 ## Reviewer Notes
 
-If [API
-changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
-are included, [additive
-changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
-must be approved by at least two
-[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards
-incompatible
-changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
-must be approved by [more than 50% of the
-OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must
-first be added [in a backwards compatible
-way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
+If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
 
 # Release Notes
 


### PR DESCRIPTION
This time for real.

Apparently GH's Markdown file rendering is slightly different from how it renders Markdown in issues? It's weird. (See below :point_down:)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API
changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive
changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two
[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards
incompatible
changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the
OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must
first be added [in a backwards compatible
way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

/assign @dibyom